### PR TITLE
make death link an option instead of the default

### DIFF
--- a/client/src/Core.cpp
+++ b/client/src/Core.cpp
@@ -18,7 +18,7 @@ VOID ClientCore::Start()
     spdlog::info("Archipelago client\n"
         "Type '/connect {SERVER_IP}:{SERVER_PORT} {SLOT_NAME} [password:{PASSWORD}]' to connect to the room\n"
         "Type '/help' for more information\n"
-        "-----------------------------------------------------\n");
+        "-----------------------------------------------------");
 
     CreateThread(NULL, NULL, (LPTHREAD_START_ROUTINE)Core->InputCommand, NULL, NULL, NULL);
 
@@ -26,7 +26,7 @@ VOID ClientCore::Start()
     while (true) {
         acplg->update();
         
-        if (GameHooks->isPlayerInGame() && GameHooks->isPlayerDead()) {
+        if (GameHooks->isDeathLink && GameHooks->isPlayerInGame() && GameHooks->isPlayerDead()) {
             acplg->sendDeathLink();
         }
 

--- a/client/src/hooks.h
+++ b/client/src/hooks.h
@@ -23,4 +23,6 @@ public:
     void clearLocations(std::list<int64_t> locationsToRemove);
 
     std::list<int64_t> getLocations();
+
+    bool isDeathLink;
 };

--- a/world/dark_souls_2/Options.py
+++ b/world/dark_souls_2/Options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from Options import PerGameCommonOptions
+from Options import PerGameCommonOptions, DeathLink
     
 @dataclass
 class DS2Options(PerGameCommonOptions):
-    pass
+    death_link: DeathLink

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -106,3 +106,6 @@ class DS2World(World):
         code = self.item_name_to_id[name]
         classification = ItemClassification.progression if name in progression_items else ItemClassification.filler
         return DS2Item(name, classification, code, self.player)
+    
+    def fill_slot_data(self) -> dict:
+        return self.options.as_dict("death_link")


### PR DESCRIPTION
- made it so we only send/receive death link when it is set as active
- added slot data to the world to send the options to the client
- client now checks the slot data and sets the death link variable and tags accordingly