### PR TITLE
Splitting enable_dlc into individual options

### DIFF
--- a/world/dark_souls_2/Locations.py
+++ b/world/dark_souls_2/Locations.py
@@ -16,7 +16,9 @@ class LocationData:
     event: Optional[bool] = False
     skip: Optional[bool] = False # if true, dont place progression items in this location
 
-dlc_regions = ["Shulva", "Brume Tower", "Eleum Loyce"]
+dlc1_regions = ["Shulva"] # Sunken King DLC
+dlc2_regions = ["Brume Tower"] # Old Iron King DLC
+dlc3_regions = ["Eleum Loyce"] # Ivory King DLC
 
 location_table = {
     "Things Betwixt": [

--- a/world/dark_souls_2/Options.py
+++ b/world/dark_souls_2/Options.py
@@ -5,9 +5,17 @@ class NoWeaponRequirements(Toggle):
     """Remove the requirements to wield weapons"""
     display_name = "No Weapon Requirements"
 
-class EnableDLCsOption(Toggle):
-    """Include items and locations exclusive to the DLCs"""
-    display_name = "Enable DLCs"
+class OldIronKingDLC(Toggle):
+    """Enable Crown of the Old Iron King DLC, randomizing items and locations within Brume Tower."""
+    display_name = "Enable Crown of the Old Iron King DLC"
+
+class IvoryKingDLC(Toggle):
+    """Enable Crown of the Ivory King DLC, randomizing items and locations within Frozen Eleum Loyce."""
+    display_name = "Enable Crown of the Ivory King DLC"
+
+class SunkenKingDLC(Toggle):
+    """Enable Crown of the Sunken King DLC, randomizing items and locations within Shulva."""
+    display_name = "Enable Crown of the Sunken King DLC"
     
 class EnableNGPOption(Toggle):
     """Include items and locations exclusive to NewGame+ cycles"""
@@ -36,7 +44,9 @@ class DS2Options(PerGameCommonOptions):
     game_version: GameVersion
     death_link: DeathLink
     no_weapon_req: NoWeaponRequirements
-    enable_dlcs: EnableDLCsOption
     enable_ngp: EnableNGPOption
     infinite_lifegems: KeepInfiniteLifegems
     exclude_locations: DS2ExcludeLocations
+    oldironkingdlc: OldIronKingDLC
+    ivorykingdlc: IvoryKingDLC
+    sunkenkingdlc: SunkenKingDLC

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -5,7 +5,7 @@ from worlds.AutoWorld import World
 from worlds.generic.Rules import set_rule, add_item_rule
 from BaseClasses import Item, ItemClassification, Location, Region, LocationProgressType
 from .Items import item_list, progression_items, repetable_categories, group_table, ItemCategory
-from .Locations import location_table, dlc_regions, location_name_groups
+from .Locations import location_table, dlc1_regions, dlc2_regions, dlc3_regions, location_name_groups
 from .Options import DS2Options
 from typing import Optional
 
@@ -52,7 +52,9 @@ class DS2World(World):
         regions["Menu"] = menu_region
     
         for region_name in location_table:
-            if region_name in dlc_regions and not self.options.enable_dlcs: continue
+            if region_name in dlc1_regions and not self.options.sunkenkingdlc: continue
+            if region_name in dlc2_regions and not self.options.oldironkingdlc: continue
+            if region_name in dlc3_regions and not self.options.ivorykingdlc: continue
             region = self.create_region(region_name)
             for location_data in location_table[region_name]:
                 if location_data.ngp and not self.options.enable_ngp: continue
@@ -110,10 +112,12 @@ class DS2World(World):
         
         regions["Aldia's Keep"].connect(regions["Dragon Aerie"])
 
-        if self.options.enable_dlcs:
-            regions["Shaded Woods"].connect(regions["Eleum Loyce"])
-            regions["Iron Keep"].connect(regions["Brume Tower"])
+        if self.options.sunkenkingdlc:
             regions["The Gutter"].connect(regions["Shulva"])
+        if self.options.oldironkingdlc:
+            regions["Iron Keep"].connect(regions["Brume Tower"])
+        if self.options.ivorykingdlc:
+            regions["Shaded Woods"].connect(regions["Eleum Loyce"])
 
     def create_region(self, name):
         return Region(name, self.player, self.multiworld)


### PR DESCRIPTION
There is now 3 options to enable DLCs separately instead of one blanket "enable_dlc" option.
![Screenshot_1](https://github.com/user-attachments/assets/a1a0e8e9-3295-43e4-a708-69a380655e81)
