### PR TITLE
Combat Logic Episode 1: Estus and Vendrick

### DIFF
--- a/world/dark_souls_2/Items.py
+++ b/world/dark_souls_2/Items.py
@@ -26,6 +26,7 @@ class ItemCategory(Enum):
     SPELL = 11
     STAFF_OR_CHIME = 12
     STATUE = 13 
+    HEALING = 14
 
 @dataclass
 class ItemData:
@@ -36,10 +37,10 @@ class ItemData:
     sotfs: Optional[bool] = False # whether the location is only in sotfs
     skip: Optional[bool] = False # if true, item will not be added to the item pool
 
-repetable_categories: list[ItemCategory] = [
+repeatable_categories: list[ItemCategory] = [
     ItemCategory.CONSUMABLE,
     ItemCategory.UPGRADE_MATERIAL,
-    ItemCategory.AMMO,
+    ItemCategory.AMMO
 ]
 
 progression_items: list[str] = [
@@ -76,7 +77,8 @@ progression_items: list[str] = [
 
 useful_items: list[str] = [
     "Estus Flask Shard",
-    "Sublime Bone Dust"
+    "Sublime Bone Dust",
+    "Soul of a Giant"
 ]
 
 item_list: list[ItemData] = [
@@ -1191,8 +1193,8 @@ item_list: list[ItemData] = [
     ItemData(60500000, "Very Good! Carving", ItemCategory.USABLE_ITEM, skip=True),
     ItemData(60510000, "Rubbish", ItemCategory.CONSUMABLE, skip=True),
     ItemData(60511000, "Petrified Something", ItemCategory.CONSUMABLE),
-    ItemData(60525000, "Estus Flask Shard", ItemCategory.CONSUMABLE),
-    ItemData(60526000, "Sublime Bone Dust", ItemCategory.CONSUMABLE),
+    ItemData(60525000, "Estus Flask Shard", ItemCategory.HEALING),
+    ItemData(60526000, "Sublime Bone Dust", ItemCategory.HEALING),
     ItemData(60527000, "Bonfire Ascetic", ItemCategory.CONSUMABLE),
     ItemData(60530000, "Alluring Skull", ItemCategory.CONSUMABLE),
     ItemData(60531000, "Lloyd's Talisman", ItemCategory.CONSUMABLE),
@@ -1353,6 +1355,7 @@ category_names = {
     ItemCategory.SPELL: "Spells",
     ItemCategory.STAFF_OR_CHIME: "Staffs and Chimes",
     ItemCategory.STATUE: "Statues",
+    ItemCategory.HEALING: "Estus Upgrades",
 }
 
 group_table: Dict[str, Set[str]] = {

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -194,6 +194,9 @@ class DS2World(World):
                 elif item_name == "Smelter Wedge":
                     if "Smelter Wedge x11" in items_in_pool: continue
                     item_data = next((item for item in item_list if item.name == "Smelter Wedge x11"), None)
+                elif item_name == "Soul of a Giant":
+                    if "Soul of a Giant" in items_in_pool: continue
+                    item_data = next((item for item in item_list if item.name == item_name), None)
                 else:
                     item_data = next((item for item in item_list if item.name == item_name), None)
                     assert item_data, f"location's default item not in item list '{item_name}'"
@@ -210,6 +213,7 @@ class DS2World(World):
                 item = self.create_item(item_data.name, item_data.category)
                 items_in_pool.append(item_data.name)
                 pool.append(item)
+                if item_data.name == "Soul of a Giant": pool.extend([item] * 4)
 
         diff = len(pool) - max_pool_size
 

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -238,7 +238,7 @@ class DS2World(World):
 
     def create_item(self, name: str, category=None) -> DS2Item:
         code = self.item_name_to_id[name]
-        classification = ItemClassification.progression if name in progression_items or category==ItemCategory.STATUE else ItemClassification.useful if name in useful_items else ItemClassification.filler
+        classification = ItemClassification.progression if name in progression_items or name in useful_items or category==ItemCategory.STATUE else ItemClassification.filler
         return DS2Item(name, classification, code, self.player, category)
 
     def is_dlc_allowed(self, dlc):
@@ -332,6 +332,10 @@ class DS2World(World):
             self.set_location_rule("[Bastille] In a cell next to Straid's cell in NG+", lambda state: state.has("Bastille Key", self.player))
     
         self.set_location_rule("[ShadedWoods] Gift from Manscorpion Tark after defeating Najka", lambda state: state.has("Ring of Whispers", self.player))
+        ## VENDRICK
+        self.set_location_rule("[Amana] On a throne behind a door that opens after defeating vendrick", lambda state: state.has("Soul of a Giant", self.player, 5))
+        self.set_location_rule("[Amana] Metal chest behind a door that opens after defeating vendrick", lambda state: state.has("Soul of a Giant", self.player, 5))
+
 
         #STATUES
         if self.options.game_version == "sotfs":

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -4,7 +4,7 @@ import random
 from worlds.AutoWorld import World, WebWorld
 from worlds.generic.Rules import set_rule, add_item_rule
 from BaseClasses import Item, ItemClassification, Location, Region, LocationProgressType, Tutorial
-from .Items import item_list, progression_items, useful_items, repetable_categories, group_table, ItemCategory, DLC
+from .Items import item_list, progression_items, useful_items, repeatable_categories, group_table, ItemCategory, DLC
 from .Locations import location_table, location_name_groups
 from .Options import DS2Options
 from typing import Optional
@@ -201,7 +201,7 @@ class DS2World(World):
                 # skip unwanted items
                 if item_data.skip: continue
                 # dont allow duplicates
-                if item_data.category not in repetable_categories and item_data.name in items_in_pool: continue
+                if item_data.category not in repeatable_categories and item_data.name not in useful_items and item_data.name in items_in_pool: continue
                 # skip sotfs items if we are not in sotfs
                 if item_data.sotfs and not self.options.game_version == "sotfs": continue
                 # skip items from dlcs not turned on
@@ -217,12 +217,12 @@ class DS2World(World):
         if diff > 0:
             while diff != 0:
                 item = random.choice(pool)
-                if item.category in repetable_categories:
+                if item.category in repeatable_categories and item.name not in useful_items:
                     pool.remove(item)
                     diff -= 1
         # fill pool with filler items
         elif diff < 0:
-            filler_items = [item for item in item_list if item.category in repetable_categories and not item.skip and not item.sotfs and self.is_dlc_allowed(item.dlc)]
+            filler_items = [item for item in item_list if item.category in repeatable_categories and not item.skip and not item.sotfs and self.is_dlc_allowed(item.dlc)]
             for _ in range(abs(diff)):
                 item_data = random.choice(filler_items)
                 item = self.create_item(item_data.name, item_data.category)


### PR DESCRIPTION
### Description of changes

- Force 5x soul of a giant, 5x sublime bone dust, and 12x estus flask shards into pool
- Require souls of a giant for vendrick's items
- "repetable" -> "repeatable"
- Adds estus flask shards and sublime bone dust as its own HEALING category, like Dark Souls 3 does

### Additional Information
Had to change the inner classification of the useful items list(sublime bone dust, estus flask shard, and now soul of a giant) to progression because the generator was getting real mad, but it's still it's own list because you need the lists distinguishable to deal with code preventing prog items from being duplicated and code that destroys consumables