### PR TITLE
Adding color text to the imgui overlay

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -182,7 +182,7 @@ typedef struct {
 
 struct ImguiTextNode {
     std::string text;
-    std::string color;
+    ImVec4* color;
 };
 
 typedef struct {
@@ -226,23 +226,26 @@ typedef struct {
 
 static ModState state = {0};
 
-ImVec4 HexToVec4(std::string hex);
-
-ImVec4 HexToVec4(std::string hex) {
-    // Basic logic: convert hex string to floats
-    // This is a simplified example; usually involves sscanf or bit shifting
-    unsigned int r, g, b;
-    sscanf(hex.c_str(), "#%02x%02x%02x", &r, &g, &b);
-    return ImVec4(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
-}
+struct ConsoleColors {
+    ImVec4 Red       = ImVec4(1.00f, 0.25f, 0.25f, 1.00f);
+    ImVec4 Green     = ImVec4(0.20f, 0.80f, 0.20f, 1.00f);
+    ImVec4 Yellow    = ImVec4(1.00f, 0.80f, 0.00f, 1.00f);
+    ImVec4 Blue      = ImVec4(0.20f, 0.50f, 1.00f, 1.00f);
+    ImVec4 Magenta   = ImVec4(0.80f, 0.30f, 0.80f, 1.00f);
+    ImVec4 Cyan      = ImVec4(0.00f, 0.80f, 0.80f, 1.00f);
+    ImVec4 Plum      = ImVec4(0.87f, 0.63f, 0.87f, 1.00f);
+    ImVec4 SlateBlue = ImVec4(0.42f, 0.35f, 0.80f, 1.00f);
+    ImVec4 Salmon    = ImVec4(1.00f, 0.50f, 0.45f, 1.00f);
+    ImVec4 Grey      = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+    ImVec4 White      = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+};
+static const ConsoleColors console_colors;
 
 void DrawTextLine(const std::list<ImguiTextNode>& lineNodes) {
     for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
-        // Convert your string color to ImVec4
-        ImVec4 cmdColor = HexToVec4(it->color);
-        
+
         // Draw the colored text
-        ImGui::TextColored(cmdColor, "%s", it->text.c_str());
+        ImGui::TextColored(*it->color, "%s", it->text.c_str());
 
         // If this isn't the last element, stay on the same line
         if (std::next(it) != lineNodes.end()) {
@@ -251,44 +254,43 @@ void DrawTextLine(const std::list<ImguiTextNode>& lineNodes) {
     }
 }
 
-std::list<ImguiTextNode>apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& msg) {
+void apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& msg) {
     std::list<ImguiTextNode> imgui_line {0};
 
     for (const auto& node: msg) {
-        std::string color;
+        ImVec4 color = console_colors.White;
         std::string text;
-        color = node.color;
         if (node.type == "player_id") {
             int id = std::stoi(node.text);
-            if (color.empty() && state.ap->slot_concerns_self(id)) color = "#FF00FF"; //magenta
-            else if (color.empty()) color = "#FFFF00"; // yellow
+            if (node.color.empty() && state.ap->slot_concerns_self(id)) color = console_colors.Magenta; //magenta
+            else if (node.color.empty()) color = console_colors.Yellow; // yellow
             text = state.ap->get_player_alias(id);
         } else if (node.type == "item_id") {
             int64_t id = std::stoll(node.text);
-            if (color.empty()) {
-                if (node.flags & APClient::ItemFlags::FLAG_ADVANCEMENT) color = "#DDA0DD"; // plum
-                else if (node.flags & APClient::ItemFlags::FLAG_NEVER_EXCLUDE) color = "#6A5ACD"; // slateblue
-                else if (node.flags & APClient::ItemFlags::FLAG_TRAP) color = "#FA8072"; // salmon
-                else color = "#00FFFF"; // cyan
+            if (node.color.empty()) {
+                if (node.flags & APClient::ItemFlags::FLAG_ADVANCEMENT) color = console_colors.Plum; // plum
+                else if (node.flags & APClient::ItemFlags::FLAG_NEVER_EXCLUDE) color = console_colors.SlateBlue; // slateblue
+                else if (node.flags & APClient::ItemFlags::FLAG_TRAP) color = console_colors.Salmon; // salmon
+                else color = console_colors.Cyan; // cyan
             }
             text = state.ap->get_item_name(id, state.ap->get_player_game(node.player));
         } else if (node.type == "location_id") {
             int64_t id = std::stoll(node.text);
-            if (color.empty()) color = "#0000FF"; // blue
+            if (node.color.empty()) color = console_colors.Blue; // blue
             text = state.ap->get_location_name(id, state.ap->get_player_game(node.player));
         } else if (node.type == "hint_status") {
             text = node.text;
-            if (node.hintStatus == APClient::HINT_FOUND) color = "#008000"; // green
-            else if (node.hintStatus == APClient::HINT_UNSPECIFIED) color = "#808080"; // grey
-            else if (node.hintStatus == APClient::HINT_NO_PRIORITY) color = "#6A5ACD"; // slateblue
-            else if (node.hintStatus == APClient::HINT_AVOID) color = "#FA8072"; // salmon
-            else if (node.hintStatus == APClient::HINT_PRIORITY) color = "#DDA0DD"; // plum
-            else color = "#FF0000";  // unknown status -> red
+            if (node.hintStatus == APClient::HINT_FOUND) color = console_colors.Green; // green
+            else if (node.hintStatus == APClient::HINT_UNSPECIFIED) color = console_colors.Grey; // grey
+            else if (node.hintStatus == APClient::HINT_NO_PRIORITY) color = console_colors.SlateBlue; // slateblue
+            else if (node.hintStatus == APClient::HINT_AVOID) color = console_colors.Salmon; // salmon
+            else if (node.hintStatus == APClient::HINT_PRIORITY) color = console_colors.Plum; // plum
+            else color = console_colors.Red;  // unknown status -> red
         } else {
             text = node.text;
         }
 
-        imgui_line.push_back(ImguiTextNode{ text, color });
+        imgui_line.push_back(ImguiTextNode{ text, color: &color });
     }
     state.imgui_log.push_back(imgui_line);
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -244,12 +244,11 @@ static const ConsoleColors console_colors;
 void DrawTextLine(const std::list<ImGuiTextNode>& lineNodes) {
     for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
 
-        // Draw the colored text
         ImGui::TextColored(*it->color, "%s", it->text.c_str());
 
         // If this isn't the last element, stay on the same line
         if (std::next(it) != lineNodes.end()) {
-            ImGui::SameLine(0.0f, 0.0f); // 0.0f spacing for tight concatenation
+            ImGui::SameLine(0.0f, 0.0f);
         }
     }
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -42,7 +42,7 @@
 
 #define PANIC(fmt, ...) do { \
     char buf[1024]; \
-    snprintf(buf, sizeof(buf), fmt, __VA_ARGS__); \
+    snprintf(buf, sizeof(buf), fmt, ##__VA_ARGS__); \
     MessageBoxA(NULL, buf, "Dark Souls II Archipelago Error", MB_OK | MB_ICONERROR); \
     ExitProcess(1); \
 } while(0)
@@ -179,6 +179,12 @@ typedef struct {
 #define MAX_SEED_SIZE 256
 #define MAX_SERVER_URI 256
 #define MAX_REFUSE_REASON 512
+
+struct ImguiTextNode {
+    std::string text;
+    std::string color;
+};
+
 typedef struct {
     int stop;
 
@@ -215,9 +221,77 @@ typedef struct {
 
     // TODO maybe cap the size
     std::vector<std::string> console_log;
+    std::vector<std::list<ImguiTextNode>> imgui_log;
 } ModState;
 
 static ModState state = {0};
+
+ImVec4 HexToVec4(std::string hex);
+
+ImVec4 HexToVec4(std::string hex) {
+    // Basic logic: convert hex string to floats
+    // This is a simplified example; usually involves sscanf or bit shifting
+    unsigned int r, g, b;
+    sscanf(hex.c_str(), "#%02x%02x%02x", &r, &g, &b);
+    return ImVec4(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
+}
+
+void DrawTextLine(const std::list<ImguiTextNode>& lineNodes) {
+    for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
+        // Convert your string color to ImVec4
+        ImVec4 cmdColor = HexToVec4(it->color);
+        
+        // Draw the colored text
+        ImGui::TextColored(cmdColor, "%s", it->text.c_str());
+
+        // If this isn't the last element, stay on the same line
+        if (std::next(it) != lineNodes.end()) {
+            ImGui::SameLine(0.0f, 0.0f); // 0.0f spacing for tight concatenation
+        }
+    }
+}
+
+std::list<ImguiTextNode>apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& msg) {
+    std::list<ImguiTextNode> imgui_line {0};
+
+    for (const auto& node: msg) {
+        std::string color;
+        std::string text;
+        color = node.color;
+        if (node.type == "player_id") {
+            int id = std::stoi(node.text);
+            if (color.empty() && state.ap->slot_concerns_self(id)) color = "#FF00FF"; //magenta
+            else if (color.empty()) color = "#FFFF00"; // yellow
+            text = state.ap->get_player_alias(id);
+        } else if (node.type == "item_id") {
+            int64_t id = std::stoll(node.text);
+            if (color.empty()) {
+                if (node.flags & APClient::ItemFlags::FLAG_ADVANCEMENT) color = "#DDA0DD"; // plum
+                else if (node.flags & APClient::ItemFlags::FLAG_NEVER_EXCLUDE) color = "#6A5ACD"; // slateblue
+                else if (node.flags & APClient::ItemFlags::FLAG_TRAP) color = "#FA8072"; // salmon
+                else color = "#00FFFF"; // cyan
+            }
+            text = state.ap->get_item_name(id, state.ap->get_player_game(node.player));
+        } else if (node.type == "location_id") {
+            int64_t id = std::stoll(node.text);
+            if (color.empty()) color = "#0000FF"; // blue
+            text = state.ap->get_location_name(id, state.ap->get_player_game(node.player));
+        } else if (node.type == "hint_status") {
+            text = node.text;
+            if (node.hintStatus == APClient::HINT_FOUND) color = "#008000"; // green
+            else if (node.hintStatus == APClient::HINT_UNSPECIFIED) color = "#808080"; // grey
+            else if (node.hintStatus == APClient::HINT_NO_PRIORITY) color = "#6A5ACD"; // slateblue
+            else if (node.hintStatus == APClient::HINT_AVOID) color = "#FA8072"; // salmon
+            else if (node.hintStatus == APClient::HINT_PRIORITY) color = "#DDA0DD"; // plum
+            else color = "#FF0000";  // unknown status -> red
+        } else {
+            text = node.text;
+        }
+
+        imgui_line.push_back(ImguiTextNode{ text, color });
+    }
+    state.imgui_log.push_back(imgui_line);
+}
 
 APLocationMapping* get_location_mapping(uint32_t location_key)
 {
@@ -800,14 +874,14 @@ void randomize()
     }
     srand(hash_seed);
 
-    ItemlotPatchContext icontext = {0};
+    ItemlotPatchContext icontext = {(APLocationType)0};
     icontext.location_type = LOC_ITEMLOT_OTHER;
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_OTHER, itemlot_prepass_fn, &icontext);
     shuffle(icontext.guaranteed, icontext.guaranteed_count, sizeof(int32_t));
     shuffle(icontext.random, icontext.random_count, sizeof(int32_t));
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_OTHER, itemlot_patch_fn, &icontext);
 
-    icontext = {0};
+    icontext = {(APLocationType)0};
     icontext.location_type = LOC_ITEMLOT_CHR;
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_CHR, itemlot_prepass_fn, &icontext);
     shuffle(icontext.guaranteed, icontext.guaranteed_count, sizeof(int32_t));
@@ -1132,6 +1206,7 @@ void ap_on_print(const std::string& msg) {
 
 void ap_on_print_json(const std::list<APClient::TextNode>& msg) {
     std::string message = state.ap->render_json(msg, APClient::RenderFormat::TEXT);
+    apclient_textnode_to_imgui_textnode(msg);
     ap_on_print(message);
 }
 
@@ -1418,16 +1493,27 @@ void render_overlay()
         if (ImGui::BeginTabItem("Console")) {
             ImGui::BeginChild("ConsoleChild", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
 
-            for (size_t i = 0; i < state.console_log.size(); ++i) {
-                const auto& line = state.console_log[i];
+            // -- OLD--
+            // for (size_t i = 0; i < state.console_log.size(); ++i) {
+            //     const auto& line = state.console_log[i];
+            //
+            //     ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+            //     ImGui::TextUnformatted(line.c_str());
+            //     ImGui::PopTextWrapPos();
+            //
+            //
+            //     if (i + 1 < state.console_log.size()) {
+            //         ImGui::Spacing();
+            //     }
+            // }
+            // -- OLD --
 
-                ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
-                ImGui::TextUnformatted(line.c_str());
-                ImGui::PopTextWrapPos();
 
-                if (i + 1 < state.console_log.size()) {
-                    ImGui::Spacing();
-                }
+            for (size_t i = 0; i < state.imgui_log.size(); ++i) {
+                const auto& imgui_line = state.imgui_log[i];
+                // -- NEW --
+                DrawTextLine(imgui_line);
+                // -- NEW --
             }
 
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -42,7 +42,7 @@
 
 #define PANIC(fmt, ...) do { \
     char buf[1024]; \
-    snprintf(buf, sizeof(buf), fmt, ##__VA_ARGS__); \
+    snprintf(buf, sizeof(buf), fmt, __VA_ARGS__); \
     MessageBoxA(NULL, buf, "Dark Souls II Archipelago Error", MB_OK | MB_ICONERROR); \
     ExitProcess(1); \
 } while(0)
@@ -876,14 +876,14 @@ void randomize()
     }
     srand(hash_seed);
 
-    ItemlotPatchContext icontext = {(APLocationType)0};
+    ItemlotPatchContext icontext = {0};
     icontext.location_type = LOC_ITEMLOT_OTHER;
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_OTHER, itemlot_prepass_fn, &icontext);
     shuffle(icontext.guaranteed, icontext.guaranteed_count, sizeof(int32_t));
     shuffle(icontext.random, icontext.random_count, sizeof(int32_t));
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_OTHER, itemlot_patch_fn, &icontext);
 
-    icontext = {(APLocationType)0};
+    icontext = {0};
     icontext.location_type = LOC_ITEMLOT_CHR;
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_CHR, itemlot_prepass_fn, &icontext);
     shuffle(icontext.guaranteed, icontext.guaranteed_count, sizeof(int32_t));
@@ -1495,27 +1495,9 @@ void render_overlay()
         if (ImGui::BeginTabItem("Console")) {
             ImGui::BeginChild("ConsoleChild", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
 
-            // -- OLD--
-            // for (size_t i = 0; i < state.console_log.size(); ++i) {
-            //     const auto& line = state.console_log[i];
-            //
-            //     ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
-            //     ImGui::TextUnformatted(line.c_str());
-            //     ImGui::PopTextWrapPos();
-            //
-            //
-            //     if (i + 1 < state.console_log.size()) {
-            //         ImGui::Spacing();
-            //     }
-            // }
-            // -- OLD --
-
-
             for (size_t i = 0; i < state.imgui_log.size(); ++i) {
                 const auto& imgui_line = state.imgui_log[i];
-                // -- NEW --
                 DrawTextLine(imgui_line);
-                // -- NEW --
             }
 
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -237,7 +237,7 @@ struct ConsoleColors {
     ImVec4 SlateBlue = ImVec4(0.42f, 0.35f, 0.80f, 1.00f);
     ImVec4 Salmon    = ImVec4(1.00f, 0.50f, 0.45f, 1.00f);
     ImVec4 Grey      = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
-    ImVec4 White      = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    ImVec4 White     = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
 };
 static const ConsoleColors console_colors;
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -42,7 +42,7 @@
 
 #define PANIC(fmt, ...) do { \
     char buf[1024]; \
-    snprintf(buf, sizeof(buf), fmt, __VA_ARGS__); \
+    snprintf(buf, sizeof(buf), fmt, ##__VA_ARGS__); \
     MessageBoxA(NULL, buf, "Dark Souls II Archipelago Error", MB_OK | MB_ICONERROR); \
     ExitProcess(1); \
 } while(0)
@@ -182,7 +182,7 @@ typedef struct {
 
 struct ImGuiTextNode {
     std::string text;
-    ImVec4* color;
+    ImVec4 color;
 };
 
 typedef struct {
@@ -244,7 +244,7 @@ static const ConsoleColors console_colors;
 void DrawTextLine(const std::list<ImGuiTextNode>& lineNodes) {
     for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
 
-        ImGui::TextColored(*it->color, "%s", it->text.c_str());
+        ImGui::TextColored(it->color, "%s", it->text.c_str());
 
         // If this isn't the last element, stay on the same line
         if (std::next(it) != lineNodes.end()) {
@@ -290,7 +290,10 @@ void apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& ms
             text = node.text;
         }
 
-        imgui_line.push_back(ImGuiTextNode{ text, color: &color });
+        ImGuiTextNode imgui_text_node;
+        imgui_text_node.text = text;
+        imgui_text_node.color = color;
+        imgui_line.push_back(imgui_text_node);
     }
     state.imgui_log.push_back(imgui_line);
 }
@@ -883,7 +886,7 @@ void randomize()
     shuffle(icontext.random, icontext.random_count, sizeof(int32_t));
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_OTHER, itemlot_patch_fn, &icontext);
 
-    icontext = {0};
+    icontext = ItemlotPatchContext{0};
     icontext.location_type = LOC_ITEMLOT_CHR;
     libds2_patch_param_table(DS2_PARAM_ITEM_LOT_PARAM2_CHR, itemlot_prepass_fn, &icontext);
     shuffle(icontext.guaranteed, icontext.guaranteed_count, sizeof(int32_t));

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -180,7 +180,7 @@ typedef struct {
 #define MAX_SERVER_URI 256
 #define MAX_REFUSE_REASON 512
 
-struct ImguiTextNode {
+struct ImGuiTextNode {
     std::string text;
     ImVec4* color;
 };
@@ -221,7 +221,7 @@ typedef struct {
 
     // TODO maybe cap the size
     std::vector<std::string> console_log;
-    std::vector<std::list<ImguiTextNode>> imgui_log;
+    std::vector<std::list<ImGuiTextNode>> imgui_log;
 } ModState;
 
 static ModState state = {0};
@@ -241,7 +241,7 @@ struct ConsoleColors {
 };
 static const ConsoleColors console_colors;
 
-void DrawTextLine(const std::list<ImguiTextNode>& lineNodes) {
+void DrawTextLine(const std::list<ImGuiTextNode>& lineNodes) {
     for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
 
         // Draw the colored text
@@ -254,8 +254,9 @@ void DrawTextLine(const std::list<ImguiTextNode>& lineNodes) {
     }
 }
 
+// stolen from apclientpp/apclient.hpp:777 render_json function, adjusted for ImGui
 void apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& msg) {
-    std::list<ImguiTextNode> imgui_line {0};
+    std::list<ImGuiTextNode> imgui_line {0};
 
     for (const auto& node: msg) {
         ImVec4 color = console_colors.White;
@@ -290,7 +291,7 @@ void apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& ms
             text = node.text;
         }
 
-        imgui_line.push_back(ImguiTextNode{ text, color: &color });
+        imgui_line.push_back(ImGuiTextNode{ text, color: &color });
     }
     state.imgui_log.push_back(imgui_line);
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -42,7 +42,7 @@
 
 #define PANIC(fmt, ...) do { \
     char buf[1024]; \
-    snprintf(buf, sizeof(buf), fmt, ##__VA_ARGS__); \
+    snprintf(buf, sizeof(buf), fmt, __VA_ARGS__); \
     MessageBoxA(NULL, buf, "Dark Souls II Archipelago Error", MB_OK | MB_ICONERROR); \
     ExitProcess(1); \
 } while(0)
@@ -226,66 +226,51 @@ typedef struct {
 
 static ModState state = {0};
 
-struct ConsoleColors {
-    ImVec4 Red       = ImVec4(1.00f, 0.25f, 0.25f, 1.00f);
-    ImVec4 Green     = ImVec4(0.20f, 0.80f, 0.20f, 1.00f);
-    ImVec4 Yellow    = ImVec4(1.00f, 0.80f, 0.00f, 1.00f);
-    ImVec4 Blue      = ImVec4(0.20f, 0.50f, 1.00f, 1.00f);
-    ImVec4 Magenta   = ImVec4(0.80f, 0.30f, 0.80f, 1.00f);
-    ImVec4 Cyan      = ImVec4(0.00f, 0.80f, 0.80f, 1.00f);
-    ImVec4 Plum      = ImVec4(0.87f, 0.63f, 0.87f, 1.00f);
-    ImVec4 SlateBlue = ImVec4(0.42f, 0.35f, 0.80f, 1.00f);
-    ImVec4 Salmon    = ImVec4(1.00f, 0.50f, 0.45f, 1.00f);
-    ImVec4 Grey      = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
-    ImVec4 White     = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
-};
-static const ConsoleColors console_colors;
-
-void DrawTextLine(const std::list<ImGuiTextNode>& lineNodes) {
-    for (auto it = lineNodes.begin(); it != lineNodes.end(); ++it) {
-
-        ImGui::TextColored(it->color, "%s", it->text.c_str());
-
-        // If this isn't the last element, stay on the same line
-        if (std::next(it) != lineNodes.end()) {
-            ImGui::SameLine(0.0f, 0.0f);
-        }
-    }
-}
+static const ImVec4 CONSOLE_COLOR_RED       = ImVec4(1.00f, 0.25f, 0.25f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_GREEN     = ImVec4(0.20f, 0.80f, 0.20f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_YELLOW    = ImVec4(1.00f, 0.80f, 0.00f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_BLUE      = ImVec4(0.20f, 0.50f, 1.00f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_MAGENTA   = ImVec4(0.80f, 0.30f, 0.80f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_CYAN      = ImVec4(0.00f, 0.80f, 0.80f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_PLUM      = ImVec4(0.87f, 0.63f, 0.87f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_SLATEBLUE = ImVec4(0.42f, 0.35f, 0.80f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_SALMON    = ImVec4(1.00f, 0.50f, 0.45f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_GREY      = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+static const ImVec4 CONSOLE_COLOR_WHITE     = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
 
 // stolen from apclientpp/apclient.hpp:777 render_json function, adjusted for ImGui
 void apclient_textnode_to_imgui_textnode(const std::list<APClient::TextNode>& msg) {
     std::list<ImGuiTextNode> imgui_line {0};
 
     for (const auto& node: msg) {
-        ImVec4 color = console_colors.White;
+        ImVec4 color = CONSOLE_COLOR_WHITE;
         std::string text;
         if (node.type == "player_id") {
             int id = std::stoi(node.text);
-            if (node.color.empty() && state.ap->slot_concerns_self(id)) color = console_colors.Magenta; //magenta
-            else if (node.color.empty()) color = console_colors.Yellow; // yellow
+            if (node.color.empty() && state.ap->slot_concerns_self(id)) color = CONSOLE_COLOR_MAGENTA; //magenta
+            else if (node.color.empty()) color = CONSOLE_COLOR_YELLOW; // yellow
             text = state.ap->get_player_alias(id);
         } else if (node.type == "item_id") {
             int64_t id = std::stoll(node.text);
             if (node.color.empty()) {
-                if (node.flags & APClient::ItemFlags::FLAG_ADVANCEMENT) color = console_colors.Plum; // plum
-                else if (node.flags & APClient::ItemFlags::FLAG_NEVER_EXCLUDE) color = console_colors.SlateBlue; // slateblue
-                else if (node.flags & APClient::ItemFlags::FLAG_TRAP) color = console_colors.Salmon; // salmon
-                else color = console_colors.Cyan; // cyan
+                if (node.flags & APClient::ItemFlags::FLAG_ADVANCEMENT) color = CONSOLE_COLOR_PLUM; // plum
+                else if (node.flags & APClient::ItemFlags::FLAG_NEVER_EXCLUDE) color = CONSOLE_COLOR_SLATEBLUE; // slateblue
+                else if (node.flags & APClient::ItemFlags::FLAG_TRAP) color = CONSOLE_COLOR_SALMON; // salmon
+                else color = CONSOLE_COLOR_CYAN; // cyan
             }
             text = state.ap->get_item_name(id, state.ap->get_player_game(node.player));
         } else if (node.type == "location_id") {
             int64_t id = std::stoll(node.text);
-            if (node.color.empty()) color = console_colors.Blue; // blue
+            if (node.color.empty()) color = CONSOLE_COLOR_BLUE; // blue
             text = state.ap->get_location_name(id, state.ap->get_player_game(node.player));
         } else if (node.type == "hint_status") {
             text = node.text;
-            if (node.hintStatus == APClient::HINT_FOUND) color = console_colors.Green; // green
-            else if (node.hintStatus == APClient::HINT_UNSPECIFIED) color = console_colors.Grey; // grey
-            else if (node.hintStatus == APClient::HINT_NO_PRIORITY) color = console_colors.SlateBlue; // slateblue
-            else if (node.hintStatus == APClient::HINT_AVOID) color = console_colors.Salmon; // salmon
-            else if (node.hintStatus == APClient::HINT_PRIORITY) color = console_colors.Plum; // plum
-            else color = console_colors.Red;  // unknown status -> red
+            if (node.hintStatus == APClient::HINT_FOUND) color = CONSOLE_COLOR_GREEN; // green
+            else if (node.hintStatus == APClient::HINT_UNSPECIFIED) color = CONSOLE_COLOR_GREY; // grey
+            else if (node.hintStatus == APClient::HINT_NO_PRIORITY) color = CONSOLE_COLOR_SLATEBLUE; // slateblue
+            else if (node.hintStatus == APClient::HINT_AVOID) color = CONSOLE_COLOR_SALMON; // salmon
+            else if (node.hintStatus == APClient::HINT_PRIORITY) color = CONSOLE_COLOR_PLUM; // plum
+            else color = CONSOLE_COLOR_RED;  // unknown status -> red
         } else {
             text = node.text;
         }
@@ -1500,7 +1485,15 @@ void render_overlay()
 
             for (size_t i = 0; i < state.imgui_log.size(); ++i) {
                 const auto& imgui_line = state.imgui_log[i];
-                DrawTextLine(imgui_line);
+                for (auto it = imgui_line.begin(); it != imgui_line.end(); ++it) {
+
+                    ImGui::TextColored(it->color, "%s", it->text.c_str());
+
+                    // If this isn't the last element, stay on the same line
+                    if (std::next(it) != imgui_line.end()) {
+                        ImGui::SameLine(0.0f, 0.0f);
+                    }
+                }
             }
 
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);


### PR DESCRIPTION
### Related Issues

N/A. I just wanted color text.

### Description of changes

- copied the render_json function from the apclient and updated it to create a vector of list\<ImGuiTextNode\> so that we can loop over those instead of regular strings
- added some default colors
- updated ap_on_print_json to call DrawTextLine to render text with associated colors

### Additional Information

This is just a quick pass at this without thinking too hard about how this should be handled. I do agree with the `// TODO maybe cap the size` to limit the number of lines we store but I didn't address that here.

<img width="595" height="239" alt="ds2_archi_color_ui" src="https://github.com/user-attachments/assets/fa2a162f-de45-433e-8d40-8cb7f4d44823" />
