### PR TITLE
Adding support for in-game location area progress tracking

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -279,10 +279,13 @@ static void build_area_progress(std::set<int64_t> checked) {
     for (int i = 0; i < state.location_mapping_count; ++i) {
         APLocationMapping* mapping = &state.location_mappings[i];
         if (mapping->location_type == LOC_SHOP_LINEUP) continue; // unsure if this is correct since shops are in regions (some shops move though)
-        if (mapping->keep_unrandomized) continue;
+        if (mapping->keep_unrandomized) continue;        
 
         for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
-            if (strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str()) == mapping->region_name) {
+            // TODO: Change this to instead be region_id so we don't have to do string comparisons (requires updating the generator)
+            char* str_str = strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str());
+            int cond = str_str == mapping->region_name;
+            if (cond) {
                 area_progress[a].total_locations++;
 
                 for (int j = 0; j < mapping->reward_count; ++j) {
@@ -1110,8 +1113,6 @@ void ap_on_slot_connected(const nlohmann::json& data)
     locations_list.insert(locations_list.end(), checked_locations.begin(), checked_locations.end());
     state.ap->LocationScouts(locations_list);
 
-    build_area_progress(checked_locations);
-
     state.slot_data_loaded = 1;
 }
 
@@ -1202,6 +1203,10 @@ void ap_on_location_info(const std::list<APClient::NetworkItem>& network_items)
             );
         }
     }
+
+    // moved to be after location rewards are populated
+    std::set<int64_t> checked_locations = state.ap->get_checked_locations();
+    build_area_progress(checked_locations);
 
     randomize();
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -134,7 +134,7 @@ typedef struct {
 typedef struct {
     uint32_t location_key;
     APLocationType location_type;
-    char region_name[64];
+    int region_id;
 
     float shop_price;
     int keep_unrandomized;
@@ -150,10 +150,11 @@ typedef struct {
 //#define MAX_SUB_REGIONS 77
 
 typedef struct {
-    std::string ap_region_prefix;
+    std::string original_name;
     int fmg_entry_id;
     int total_locations;
     int checked_locations;
+    wchar_t name_with_progress[MAX_AREA_NAME_LEN];
 } AreaProgress;
 
 // TODO: actually match prefix, these are the strings from the game itself
@@ -161,15 +162,15 @@ static AreaProgress area_progress[MAX_MAIN_REGIONS] = {
     { "Majula", 10040000 },
     { "Shaded Woods", 10320000 },
     { "Things Betwixt", 10020000 },
-    { "Forest of Fallen Giants", 10100000 }, // WTF do I do about the memory items like from Memory of Jeigh
+    { "Forest of Fallen Giants", 10100000 },
     { "Throne of Want", 20210002 },
-    { "Frozen Eleum Loyce ", 50370000 }, // TODO: Frigid Outskirts, should be under Frozen Eleum Loyce, same as others
-    { "Grand Cathedral", 50370001 },
+    { "Frozen Eleum Loyce ", 50370000 },
+    { "Grand Cathedral", 50370001 }, // no items in AP -- could move some from Frozen Eleum Loyce
     { "Iron Passage", 50360001 },
-    { "Brume Tower", 50360000 }, // TODO: IDK if this goes here: Memory of the Old Iron King
-    { "Dragon's Rest", 50350002 },
+    { "Brume Tower", 50360000 },
+    { "Dragon's Rest", 50350002 }, // no items in AP -- could move some from Dragon's Sanctum
     { "Dragon's Sanctum", 50350001 },
-    { "Shulva, Sanctum City", 50350000 }, // TODO: Figure out how to fix Cave of The Dead, doesn't contain this prefix in locations.py when it should for main areas
+    { "Shulva, Sanctum City", 50350000 },
     { "Dragon Shrine", 10270001 },
     { "Dragon Aerie", 10270000 },
     { "Aldia's Keep", 10150000 },
@@ -182,7 +183,7 @@ static AreaProgress area_progress[MAX_MAIN_REGIONS] = {
     { "Shrine of Amana", 20110000 },
     { "Drangleic Castle", 20210000 },
     { "Brightstone Cove Tseldora", 10140000 },
-    { "The Gutter", 10250000 }, // TODO: The Pit needs to be in here
+    { "The Gutter", 10250000 },
     { "Grave of Saints", 10340000 },
     { "Belfry Sol", 10190001 },
     { "Iron Keep", 10190000 },
@@ -278,19 +279,14 @@ static void build_area_progress(std::set<int64_t> checked) {
 
     for (int i = 0; i < state.location_mapping_count; ++i) {
         APLocationMapping* mapping = &state.location_mappings[i];
-        if (mapping->location_type == LOC_SHOP_LINEUP) continue; // unsure if this is correct since shops are in regions (some shops move though)
+        //if (mapping->location_type == LOC_SHOP_LINEUP) continue; // unsure if this is correct since shops are in regions (some shops move though)
         if (mapping->keep_unrandomized) continue;        
 
         for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
-            // TODO: Change this to instead be region_id so we don't have to do string comparisons (requires updating the generator)
-            char* str_str = strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str());
-            int cond = str_str == mapping->region_name;
-            if (cond) {
+            if (area_progress[a].fmg_entry_id == mapping->region_id) {
                 area_progress[a].total_locations++;
 
                 for (int j = 0; j < mapping->reward_count; ++j) {
-                    // TODO: do we need to handle bundles???
-                    // TODO: Maybe only the first match and break? maybe it doesn't matter percentage wise, just inflates totals
                     if (checked.find(mapping->location_rewards[j].archipelago_id) != checked.end()) {
                         area_progress[a].checked_locations++;
                         break;
@@ -298,6 +294,20 @@ static void build_area_progress(std::set<int64_t> checked) {
                 }
             }
         }
+    }
+
+    // Setup names
+    for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
+        float total = area_progress[a].total_locations;
+
+        if ((int)total == 0) {
+            swprintf(area_progress[a].name_with_progress, MAX_AREA_NAME_LEN, L"%S - No AP items in pool", area_progress[a].original_name.c_str());
+            continue;
+        }
+        float checked = area_progress[a].checked_locations;
+        int pct = (total > 0) ? round(checked * 100 / total) : 0;
+
+        swprintf(area_progress[a].name_with_progress, MAX_AREA_NAME_LEN, L"%S - %d/%d (%d%%)", area_progress[a].original_name.c_str(), (int)checked, (int)total, pct);
     }
 }
 
@@ -587,15 +597,7 @@ const wchar_t* __cdecl detour_get_fmg_entry(DS2FMGFileID file_id, int32_t entry_
     if (file_id == DS2_FMG_MAIN_REGION_NAMES && area_initialized) {
         for (int i = 0; i < MAX_MAIN_REGIONS; ++i) {
             if (area_progress[i].fmg_entry_id == entry_id) {
-                static wchar_t buf[MAX_AREA_NAME_LEN];
-
-                int total = area_progress[i].total_locations;
-                int checked = area_progress[i].checked_locations;
-                int pct = (total > 0) ? (checked * 100 / total) : 0;
-
-                swprintf(buf, MAX_AREA_NAME_LEN, L"%s - %d/%d (%d%%)", original_name, checked, total, pct);
-
-                return buf;
+                return area_progress[i].name_with_progress;
             }
         }
     }
@@ -1026,9 +1028,9 @@ void ap_on_slot_connected(const nlohmann::json& data)
         APLocationMapping* mapping = &state.location_mappings[state.location_mapping_count++];
         mapping->location_key = entry.at("location_key").get<int64_t>();
         
-        if (entry.contains("region_name")) {
-            std::string region_name = entry.at("region_name").get<std::string>();
-            strncpy_s(mapping->region_name, sizeof(mapping->region_name), region_name.c_str(), _TRUNCATE);
+        if (entry.contains("region_id")) {
+            int region_id = entry.at("region_id").get<int>();
+            mapping->region_id = region_id;
         }
 
         if (mapping->location_key >= LOC_SHOP_LINEUP) {
@@ -1280,10 +1282,17 @@ void handle_check_locations()
         APLocationMapping* mapping = get_location_mapping(location_key);
         if (!mapping) continue;
 
-        if (area_initialized && !mapping->keep_unrandomized && mapping->location_type != LOC_SHOP_LINEUP) {
+        // unsure if we should ignore shops or not, placement is somewhat unclear (in as far as moving shops go)
+        if (area_initialized && !mapping->keep_unrandomized /*&& mapping->location_type != LOC_SHOP_LINEUP*/) {
             for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
-                if (strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str()) == mapping->region_name) {
+                if (area_progress[a].fmg_entry_id == mapping->region_id) {
                     area_progress[a].checked_locations++;
+
+                    float total = area_progress[a].total_locations;
+                    float checked = area_progress[a].checked_locations;
+                    int pct = (total > 0) ? round(checked * 100 / total) : 0;
+
+                    swprintf(area_progress[a].name_with_progress, MAX_AREA_NAME_LEN, L"%S - %d/%d (%d%%)", area_progress[a].original_name.c_str(), (int)checked, (int)total, pct);
                     break;
                 }
             }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -134,6 +134,7 @@ typedef struct {
 typedef struct {
     uint32_t location_key;
     APLocationType location_type;
+    char region_name[64];
 
     float shop_price;
     int keep_unrandomized;
@@ -143,6 +144,57 @@ typedef struct {
     LocationReward location_rewards[MAX_LOCATION_REWARDS];
     int reward_count;
 } APLocationMapping;
+
+#define MAX_AREA_NAME_LEN 64
+#define MAX_MAIN_REGIONS 35
+//#define MAX_SUB_REGIONS 77
+
+typedef struct {
+    std::string ap_region_prefix;
+    int fmg_entry_id;
+    int total_locations;
+    int checked_locations;
+} AreaProgress;
+
+// TODO: actually match prefix, these are the strings from the game itself
+static AreaProgress area_progress[MAX_MAIN_REGIONS] = {
+    { "Majula", 10040000 },
+    { "Shaded Woods", 10320000 },
+    { "Things Betwixt", 10020000 },
+    { "Forest of Fallen Giants", 10100000 }, // WTF do I do about the memory items like from Memory of Jeigh
+    { "Throne of Want", 20210002 },
+    { "Frozen Eleum Loyce ", 50370000 }, // TODO: Frigid Outskirts, should be under Frozen Eleum Loyce, same as others
+    { "Grand Cathedral", 50370001 },
+    { "Iron Passage", 50360001 },
+    { "Brume Tower", 50360000 }, // TODO: IDK if this goes here: Memory of the Old Iron King
+    { "Dragon's Rest", 50350002 },
+    { "Dragon's Sanctum", 50350001 },
+    { "Shulva, Sanctum City", 50350000 }, // TODO: Figure out how to fix Cave of The Dead, doesn't contain this prefix in locations.py when it should for main areas
+    { "Dragon Shrine", 10270001 },
+    { "Dragon Aerie", 10270000 },
+    { "Aldia's Keep", 10150000 },
+    { "Undead Crypt", 20240000 },
+    { "Cathedral of Blue", 10310001 },
+    { "Belfry Luna", 10160002 },
+    { "Earthen Peak", 10170001 },
+    { "Doors of Pharros", 10330000 },
+    { "Black Gulch", 10250001 },
+    { "Shrine of Amana", 20110000 },
+    { "Drangleic Castle", 20210000 },
+    { "Brightstone Cove Tseldora", 10140000 },
+    { "The Gutter", 10250000 }, // TODO: The Pit needs to be in here
+    { "Grave of Saints", 10340000 },
+    { "Belfry Sol", 10190001 },
+    { "Iron Keep", 10190000 },
+    { "Harvest Valley", 10170000 },
+    { "Undead Purgatory", 10230001 },
+    { "Huntsman's Copse", 10230000 },
+    { "Sinners' Rise", 10160001 },
+    { "The Lost Bastille", 10160000 },
+    { "No-man's Wharf", 10180000 },
+    { "Heide's Tower of Flame", 10310000 }
+};
+static int area_initialized = 0;
 
 enum APItemType {
     APITEM_ITEM  = 1,
@@ -218,6 +270,33 @@ typedef struct {
 } ModState;
 
 static ModState state = {0};
+
+static void build_area_progress(std::set<int64_t> checked) {
+    if (area_initialized) return;
+
+    area_initialized = 1;
+
+    for (int i = 0; i < state.location_mapping_count; ++i) {
+        APLocationMapping* mapping = &state.location_mappings[i];
+        if (mapping->location_type == LOC_SHOP_LINEUP) continue; // unsure if this is correct since shops are in regions (some shops move though)
+        if (mapping->keep_unrandomized) continue;
+
+        for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
+            if (strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str()) == mapping->region_name) {
+                area_progress[a].total_locations++;
+
+                for (int j = 0; j < mapping->reward_count; ++j) {
+                    // TODO: do we need to handle bundles???
+                    // TODO: Maybe only the first match and break? maybe it doesn't matter percentage wise, just inflates totals
+                    if (checked.find(mapping->location_rewards[j].archipelago_id) != checked.end()) {
+                        area_progress[a].checked_locations++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
 
 APLocationMapping* get_location_mapping(uint32_t location_key)
 {
@@ -500,11 +579,28 @@ void remove_special_characters(const wchar_t* input, wchar_t* output, int max_le
 
 const wchar_t* __cdecl detour_get_fmg_entry(DS2FMGFileID file_id, int32_t entry_id)
 {
-    static wchar_t cleaned_name[MAX_ITEM_NAME];
+    const wchar_t* original_name = original_get_fmg_entry(file_id, entry_id);
+
+    if (file_id == DS2_FMG_MAIN_REGION_NAMES && area_initialized) {
+        for (int i = 0; i < MAX_MAIN_REGIONS; ++i) {
+            if (area_progress[i].fmg_entry_id == entry_id) {
+                static wchar_t buf[MAX_AREA_NAME_LEN];
+
+                int total = area_progress[i].total_locations;
+                int checked = area_progress[i].checked_locations;
+                int pct = (total > 0) ? (checked * 100 / total) : 0;
+
+                swprintf(buf, MAX_AREA_NAME_LEN, L"%s - %d/%d (%d%%)", original_name, checked, total, pct);
+
+                return buf;
+            }
+        }
+    }
 
     if (file_id == DS2_FMG_ITEM_NAMES) {
         UnusedItem* unused_item = get_unused_item(entry_id);
         if (unused_item && unused_item->item_name[0] != L'\0') {
+            static wchar_t cleaned_name[MAX_ITEM_NAME];
 
             remove_special_characters(
                 unused_item->item_name,
@@ -516,7 +612,7 @@ const wchar_t* __cdecl detour_get_fmg_entry(DS2FMGFileID file_id, int32_t entry_
         }
     }
 
-    return original_get_fmg_entry(file_id, entry_id);
+    return original_name;
 }
 
 #if DS2_64
@@ -926,6 +1022,11 @@ void ap_on_slot_connected(const nlohmann::json& data)
         const nlohmann::json& entry = locations[i];
         APLocationMapping* mapping = &state.location_mappings[state.location_mapping_count++];
         mapping->location_key = entry.at("location_key").get<int64_t>();
+        
+        if (entry.contains("region_name")) {
+            std::string region_name = entry.at("region_name").get<std::string>();
+            strncpy_s(mapping->region_name, sizeof(mapping->region_name), region_name.c_str(), _TRUNCATE);
+        }
 
         if (mapping->location_key >= LOC_SHOP_LINEUP) {
             mapping->location_type = LOC_SHOP_LINEUP;
@@ -1008,6 +1109,8 @@ void ap_on_slot_connected(const nlohmann::json& data)
     locations_list.insert(locations_list.end(), missing_locations.begin(), missing_locations.end());
     locations_list.insert(locations_list.end(), checked_locations.begin(), checked_locations.end());
     state.ap->LocationScouts(locations_list);
+
+    build_area_progress(checked_locations);
 
     state.slot_data_loaded = 1;
 }
@@ -1171,6 +1274,15 @@ void handle_check_locations()
 
         APLocationMapping* mapping = get_location_mapping(location_key);
         if (!mapping) continue;
+
+        if (area_initialized && !mapping->keep_unrandomized && mapping->location_type != LOC_SHOP_LINEUP) {
+            for (int a = 0; a < MAX_MAIN_REGIONS; ++a) {
+                if (strstr(mapping->region_name, area_progress[a].ap_region_prefix.c_str()) == mapping->region_name) {
+                    area_progress[a].checked_locations++;
+                    break;
+                }
+            }
+        }
 
         for (int i = 0; i < mapping->reward_count; ++i) {
             ids_to_check.push_back(mapping->location_rewards[i].archipelago_id);

--- a/src/ds2.h
+++ b/src/ds2.h
@@ -331,8 +331,10 @@ typedef enum {
 } DS2GameState;
 
 typedef enum {
-    DS2_FMG_ITEM_NAMES     = 8,
-    DS2_FMG_ITEM_SUMMARIES = 9
+    DS2_FMG_MAIN_REGION_NAMES = 5,
+    DS2_FMG_ITEM_NAMES        = 8,
+    DS2_FMG_ITEM_SUMMARIES    = 9,
+    DS2_FMG_SUB_REGION_NAMES  = 18
 } DS2FMGFileID;
 
 /* =========================================================


### PR DESCRIPTION
### Related Issues
N/A: I just wanted to see if we could have in-game tracking of area progress.
Relies on this [PR](https://github.com/WildBunnie/Archipelago/pull/4) to function.

### Description of changes
* location pickup count and percent will be associated with a region, visible in the fast travel menu
* added a list of regions with the entry_id that is pulled by the UI
* added an initial function called when the slot is connected to get last state of locations checked
* update the area progress as locations are checked
- [x] TODO: swap usage of region_name to region_id (requires generator change) to avoid messing with existing region names (currently more specific, I.E. memories in FOFG)
- [x] TODO: consider supporting sub-regions as well (just bonfire locations), likely much harder to associated specific pickups with a specific bonfire
  - We definitely can support sub regions but that would require the vast majority of locations getting updated to have the bonfire_id set. This would require a larger effort to assign a specific bonfire for that location that makes sense, but I suspect multiple bonfires will overlap.
- [x] TODO: Figure out if the bundles are accounted for (essentially just avoiding the number getting higher than it should)
  - bundles are accounted for via break on location rewards

- [x] TODO: Figure out if we can support shops (might be difficult since some shops move)
  - we now support shops via the location region_id overriding the location group region_id

### Additional Information
* Technically this will change the text for ANY reference to these areas (I believe at least in menus)
* "Grand Cathedral" and "Dragon's Rest" do not have any AP items. This could be changed to take a select few that are currently grouped into "Frozen Eleum Loyce" and "Dragon's Sanctum" respectively.
* Note: this does not have an updated total and percentage based on what is accessible by logic. If is purely the location counts that exist in each region. Adding in support for logical tracking would be a larger undertaking.

<img width="1055" height="370" alt="map_progress" src="https://github.com/user-attachments/assets/44ba2bd7-182e-4f90-b001-e3ff45590d79" />
