### PR TITLE
added vanilla ammo progression option

### DIFF
--- a/client/src/archipelago.cpp
+++ b/client/src/archipelago.cpp
@@ -123,6 +123,19 @@ void setup_apclient(std::string URI, std::string slot_name, std::string password
 			locations_to_ignore.insert(75400601);
 		}
 
+		// Vanilla Ammo Progression, skips all shop ammo locations
+		if (data.contains("vanilla_ammo") && data.at("vanilla_ammo") == 1)
+		{
+			locations_to_ignore.insert({76400600, 76400601, 76400602, 76400603, // Lenigrast: Wood and Iron arrows and bolts
+										76430600, 76430601, 76430602, 76430603, 76430604, // McDuff: Wood and Iron arrows and bolts, Plus Iron Great
+										77600601, 77600602, // Ornifex: Fire arrows and bolts 
+										72600603, 72600607, // Gavlan: 2(?) poison arrow slots
+										72110604, 72110605, 72110606, 72110607, // Wellager: Magic and Lightning arrows and bolts
+										50600602, 50600603, // Agdayne: Dark Arrows and Bollts
+										77100602, 77100603, 77100604, // Navlaan: Lightning, Fire, and Destructive greatarrows
+										30700602 }); // Vengarl: Destructive greatarrows
+		}
+
 		if (data.contains("randomize_starting_loadout") && data.at("randomize_starting_loadout") == 1) {
 			if (data.contains("starting_weapon_requirement")) {
 				ClassRandomizationFlag flag = static_cast<ClassRandomizationFlag>(data.at("starting_weapon_requirement"));

--- a/world/dark_souls_2/Options.py
+++ b/world/dark_souls_2/Options.py
@@ -84,6 +84,10 @@ class KeepInfiniteLifegems(Toggle):
     """Keep Melentia's infinite supply of lifegems"""
     display_name = "Keep Infinite Lifegems"
 
+class KeepVanillaAmmo(Toggle):
+    """Keep arrows, bolts, and greatarrows sold by shopkeepers"""
+    display_name = "Vanilla Ammo Vendors"
+
 class DS2ExcludeLocations(ExcludeLocations):
     """Prevent these locations from having an important item."""
     default = frozenset({"Dark Chasm of Old"})
@@ -106,6 +110,7 @@ class DS2Options(PerGameCommonOptions):
     enable_ngp: EnableNGPOption
     early_blacksmith: EarlyBlacksmith
     infinite_lifegems: KeepInfiniteLifegems
+    vanilla_ammo: KeepVanillaAmmo
     exclude_locations: DS2ExcludeLocations
     start_inventory: DS2StartInventory
     old_iron_king_dlc: OldIronKingDLC

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -547,4 +547,4 @@ class DS2World(World):
         if self.options.combat_logic == "disabled": return
 
     def fill_slot_data(self) -> dict:
-        return self.options.as_dict("death_link","game_version","no_weapon_req","no_spell_req","no_equip_load","infinite_lifegems","randomize_starting_loadout", "starting_weapon_requirement", "autoequip")
+        return self.options.as_dict("death_link","game_version","no_weapon_req","no_spell_req","no_equip_load","infinite_lifegems", "vanilla_ammo","randomize_starting_loadout", "starting_weapon_requirement", "autoequip")


### PR DESCRIPTION
### Related Issues

Closes #73. 

### Description of changes

Adds an additional toggle in configuration which leaves all arrows, bolts, and greatarrows from shopkeepers in their original locations.