### PR TITLE
added early dull ember option

### DIFF
--- a/world/dark_souls_2/Options.py
+++ b/world/dark_souls_2/Options.py
@@ -73,11 +73,13 @@ class CombatLogic(Choice):
     default = option_medium
 
 class EarlyBlacksmith(Choice):
-    """Force Lenigrast's key into an early sphere in your world or across all worlds."""
+    """Force Lenigrast's key and the Dull Ember into an early sphere in your world or across all worlds."""
     display_name = "Early Blacksmith"
     option_anywhere = 0
     option_early_global = 1
     option_early_local = 2
+    option_early_global_with_ember = 3
+    option_early_local_with_ember = 4
     default = option_early_local
 
 class KeepInfiniteLifegems(Toggle):

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -60,6 +60,13 @@ class DS2World(World):
             self.multiworld.early_items[self.player]["Lenigrast's Key"] = 1
         elif self.options.early_blacksmith == "early_local":
             self.multiworld.local_early_items[self.player]["Lenigrast's Key"] = 1
+        elif self.options.early_blacksmith == "early_global_with_ember":
+            self.multiworld.early_items[self.player]["Lenigrast's Key"] = 1
+            self.multiworld.early_items[self.player]["Dull Ember"] = 1
+        elif self.options.early_blacksmith == "early_local_with_ember":
+            self.multiworld.local_early_items[self.player]["Lenigrast's Key"] = 1
+            self.multiworld.local_early_items[self.player]["Dull Ember"] = 1
+
 
     def create_regions(self):
 

--- a/world/dark_souls_2/__init__.py
+++ b/world/dark_souls_2/__init__.py
@@ -67,7 +67,6 @@ class DS2World(World):
             self.multiworld.local_early_items[self.player]["Lenigrast's Key"] = 1
             self.multiworld.local_early_items[self.player]["Dull Ember"] = 1
 
-
     def create_regions(self):
 
         regions = {}


### PR DESCRIPTION
### Related Issues

None. New feature.

### Description of changes

Added two additional options for Early Blacksmith, adding the Dull Ember as either an early local or early global item and guaranteeing early access to weapon infusions. Could be broken out into a separate option to force an early McDuff, but I didn't see the need.
